### PR TITLE
Fix example jpg to png (IE problem)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,12 +20,12 @@ app.configure(function(){
     app.use(express.bodyParser());
 	app.use(express.cookieParser());
 	app.use(express.cookieSession({ secret: 'keyboard-cat' }));
-	app.use(captcha({ url: '/captcha.jpg', color:'#0064cd', background: 'rgb(20,30,200)' })); // captcha params
+	app.use(captcha({ url: '/captcha.png', color:'#0064cd', background: 'rgb(20,30,200)' })); // captcha params
 });
 
 app.get('/', function(req, res){
 	res.type('html');
-	res.end('<img src="/captcha.jpg"/><form action="/login" method="post"><input type="text" name="digits"/></form>'); // captcha render
+	res.end('<img src="/captcha.png"/><form action="/login" method="post"><input type="text" name="digits"/></form>'); // captcha render
 });
 
 app.post('/login', function(req, res){


### PR DESCRIPTION
According to https://github.com/learnboost/node-canvas#canvastobuffer, 
canvas.toBuffer will return buffer containing PNG data.

`<img src="/captcha.jpg">` seems to work fine in most browsers, but it doesn't work in IE8 - IE10, and even in IE11 (works on IE7).

IE screenshots (link might expire):
http://www.browserstack.com/screenshots/e39d4e6998280987116732a8346bf68cb5a4e465
