### PR TITLE
Easier reload

### DIFF
--- a/captcha.js
+++ b/captcha.js
@@ -7,7 +7,7 @@ module.exports = function(params){
     params.background = params.background || 'rgb(255,200,150)';
 
 	return function(req, res, next){
-		if(req.path != params.url)
+		if(req.path.replace(/[?].*/gi,"") != params.url)
 			return next();
 
 		var canvas = new Canvas(250, 150);


### PR DESCRIPTION
Now, if you add a query string to the captcha url, it does not generate a 404 error. 

In this way, you can easily reload it by calling 
<code>$("img").attr("src",$("img").attr("src") + "?somestring")</code>
to load a different img.
