### PR TITLE
make default fontSize, lineWidth and offsets relative to canvas dimensions

### DIFF
--- a/captcha.js
+++ b/captcha.js
@@ -5,12 +5,11 @@ module.exports = function(params){
         params = { url: params };
     params.color = params.color || 'rgb(0,100,100)';
     params.background = params.background || 'rgb(255,200,150)';
-    params.lineWidth = params.lineWidth || 8;
-    params.fontSize = params.fontSize || 80;
     params.codeLength = params.codeLength || 6;
     params.canvasWidth = params.canvasWidth || 250;
     params.canvasHeight = params.canvasHeight || 150;
-
+    params.fontSize = params.fontSize || params.canvasHeight * 0.7;
+    params.lineWidth = params.lineWidth || Math.ceil(params.fontSize / 10);
 
     return function(req, res, next){
         if(req.path != params.url)
@@ -20,23 +19,30 @@ module.exports = function(params){
         var ctx = canvas.getContext('2d');
         ctx.antialias = 'gray';
         ctx.fillStyle = params.background;
-        ctx.fillRect(0, 0, 250, 150);
+        ctx.fillRect(0, 0, params.canvasWidth, params.canvasHeight);
         ctx.fillStyle = params.color;
         ctx.lineWidth = params.lineWidth;
         ctx.strokeStyle = params.color;
         ctx.font = params.fontSize+'px sans';
 
         for (var i = 0; i < 2; i++) {
-            ctx.moveTo(20, Math.random() * 150);
-            ctx.bezierCurveTo(80, Math.random() * 150, 160, Math.random() * 150, 230, Math.random() * 150);
+            ctx.moveTo(params.canvasWidth * 0.05, Math.random() * params.canvasHeight);
+            ctx.bezierCurveTo(params.canvasWidth * 0.33, Math.random() * params.canvasHeight, params.canvasWidth * 0.66, Math.random() * params.canvasHeight, params.canvasWidth * 0.95, Math.random() * params.canvasHeight);
             ctx.stroke();
         }
 
 		var text = params.text || ('' + Math.random()).substr(3, params.codeLength);
+    var fontWidth = (params.fontSize / 2);
+    var marginY = (params.canvasWidth - (fontWidth * text.length)) / 2;
 
-      for (i = 0; i < text.length; i++) {
-			ctx.setTransform(Math.random() * 0.5 + 1, Math.random() * 0.4, Math.random() * 0.4, Math.random() * 0.5 + 1, 30 * i + 20, 100);
-			ctx.fillText(text.charAt(i), 0, 0);
+    if (marginY < 0) {
+        marginY = params.canvasWidth * 0.05;
+        fontWidth = (params.canvasWidth * 0.9) / text.length;
+    }
+
+    for (i = 0; i < text.length; i++) {
+        ctx.setTransform(Math.random() * 0.5 + 1, Math.random() * 0.4, Math.random() * 0.4, Math.random() * 0.5 + 1, marginY + fontWidth * i, params.fontSize + params.fontSize * 0.25);
+        ctx.fillText(text.charAt(i), 0, 0);
 		}
 
 //	    ctx.setTransform(1, 0, 0, 1, 0, 0);

--- a/captcha.js
+++ b/captcha.js
@@ -36,7 +36,7 @@ module.exports = function(params){
     var marginY = (params.canvasWidth - (fontWidth * text.length)) / 2;
 
     if (marginY < 0) {
-        marginY = params.canvasWidth * 0.05;
+        marginY = 0;
         fontWidth = (params.canvasWidth * 0.9) / text.length;
     }
 


### PR DESCRIPTION
Hi, I tried to make canvasHeight and canvasWidth to work properly. As I saw in the source, all canvas operations used hardcoded dimensions so I changed them to be relative to actual canvas size.

Here is a couple of examples:

![captcha_default](https://cloud.githubusercontent.com/assets/1392262/9848720/14982de6-5afd-11e5-8cd1-c4c3ab5e350e.jpg)
![captcha_smaller_height](https://cloud.githubusercontent.com/assets/1392262/9848721/14b58788-5afd-11e5-9ea0-caf935d6f0c8.jpg)

