### PR TITLE
Adjustment of between-number intervals according to canvasWidth

### DIFF
--- a/captcha.js
+++ b/captcha.js
@@ -27,7 +27,7 @@ module.exports = function(params){
         ctx.font = params.fontSize+'px sans';
 
         for (var i = 0; i < 2; i++) {
-            ctx.moveTo(Math.floor(0.08*params.canvasWidth), Math.random() * params.canvasHeight);
+            ctx.moveTo(0, Math.random() * params.canvasHeight);
             ctx.bezierCurveTo(Math.floor(0.32*params.canvasWidth), Math.random() * params.canvasHeight, Math.floor(1.07*params.canvasHeight), Math.random() * params.canvasHeight, Math.floor(0.92*params.canvasWidth), Math.random() * params.canvasHeight);
             ctx.stroke();
         }
@@ -35,7 +35,7 @@ module.exports = function(params){
                 var text = params.text || ('' + Math.random()).substr(3, params.codeLength);
 
       for (i = 0; i < text.length; i++) {
-                        ctx.setTransform(Math.random() * 0.5 + 1, Math.random() * 0.4, Math.random() * 0.4, Math.random() * 0.5 + 1, Math.floor(0.375*params.fontSize) * i + Math.floor(0.25*params.fontSize), Math.floor(1.25*params.fontSize));
+                        ctx.setTransform(Math.random() * 0.5 + 1, Math.random() * 0.4, Math.random() * 0.4, Math.random() * 0.5 + 1, Math.floor(params.canvasWidth/params.codeLength) * i + Math.floor(0.25*params.fontSize), Math.floor(1.25*params.fontSize));
                         ctx.fillText(text.charAt(i), 0, 0);
                 }
 


### PR DESCRIPTION
Tested 4 length code on wide canvas (200px). Adjusted font letter intervals to match all canvas width.
Now it looks like:
![screenshot_20160311_113437](https://cloud.githubusercontent.com/assets/5525262/13697280/79f95a5e-e77d-11e5-8e42-4c2beaae3973.png)
